### PR TITLE
Fix Mermaid diagram syntax errors and correct actor model

### DIFF
--- a/docs/domain/class-diagram.md
+++ b/docs/domain/class-diagram.md
@@ -197,7 +197,6 @@ classDiagram
     Sport "1" --> "0..*" CalendarAccess : controls
     Sport "1" --> "0..*" SessionTemplate : defines
     Venue "1" --> "0..*" TrainingSession : hosts
-    Venue "N" -.-> "N" Sport : tagged with
     SessionTemplate "1" -.-> "0..*" TrainingSession : generates
     TrainingSession "1" --> "0..*" Attendance : has
     User "1" --> "0..*" Attendance : participates

--- a/docs/domain/er-diagram.md
+++ b/docs/domain/er-diagram.md
@@ -39,7 +39,7 @@ erDiagram
 
     ATHLETE_PROFILE {
         uuid id PK
-        uuid user_id FK UK "unique"
+        uuid user_id FK "unique"
         string level "BEGINNER|INTERMEDIATE|ADVANCED"
         timestamp created_at
         timestamp updated_at

--- a/docs/domain/use-cases.md
+++ b/docs/domain/use-cases.md
@@ -6,16 +6,24 @@ This document visualizes the interactions between actors and the system.
 
 ```mermaid
 graph LR
-    Athlete[👤 Athlete]
-    Supporter[👤 Supporter]
-    Committee[👨‍💼 Committee]
+    User[👤 User]
 
-    Athlete -->|extends| User
-    Supporter -->|extends| User
-    Committee -->|extends| User
+    User -->|has role| Athlete[ATHLETE]
+    User -->|has role| Supporter[SUPPORTER]
+    User -->|has role| Committee[COMMITTEE]
 
-    User[Base User]
+    Committee -->|has privileges| Privileges[Committee Privileges]
+
+    style User fill:#e1f5ff
+    style Athlete fill:#d4edda
+    style Supporter fill:#fff3cd
+    style Committee fill:#f8d7da
 ```
+
+**Note:** Users can have multiple roles simultaneously:
+- ✅ ATHLETE + COMMITTEE
+- ✅ SUPPORTER + COMMITTEE
+- ❌ ATHLETE + SUPPORTER (mutually exclusive)
 
 ## Complete Use Case Diagram
 


### PR DESCRIPTION
**Fixes:**
1. class-diagram.md: Remove invalid Venue-Sport many-to-many relationship syntax
   - Relationship is managed through sportTags JSON field, not direct relation

2. er-diagram.md: Fix ATHLETE_PROFILE.user_id constraint notation
   - Changed from "FK UK" to "FK" with "unique" comment (valid Mermaid syntax)

3. use-cases.md: Correct Actor Overview diagram
   - Removed incorrect inheritance/extends model (Base User)
   - Updated to show single User class with has-role relationships
   - Added note about valid role combinations
   - Reflects actual multi-role system design

**Result:** All Mermaid diagrams now render correctly and accurately represent the domain model with single User class + UserRole entities.