### PR TITLE
Fix SessionTemplate relationship syntax in class diagram

### DIFF
--- a/docs/domain/class-diagram.md
+++ b/docs/domain/class-diagram.md
@@ -197,7 +197,7 @@ classDiagram
     Sport "1" --> "0..*" CalendarAccess : controls
     Sport "1" --> "0..*" SessionTemplate : defines
     Venue "1" --> "0..*" TrainingSession : hosts
-    SessionTemplate "1" -.-> "0..*" TrainingSession : generates
+    SessionTemplate "1" ..> "0..*" TrainingSession : generates
     TrainingSession "1" --> "0..*" Attendance : has
     User "1" --> "0..*" Attendance : participates
 


### PR DESCRIPTION
Changed dotted line syntax from -.-> to ..> (dependency relationship) This is the correct Mermaid syntax for showing that SessionTemplate generates TrainingSession instances.