### PR TITLE
Make AthleteProfile sport-specific and fix circular relationships

### DIFF
--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -85,30 +85,35 @@ Defines what a user can do in the system through role assignment with granular C
 
 ### 3. AthleteProfile
 
-Stores athlete-specific information including skill level for informational purposes.
+Stores athlete-specific information including skill level per sport for informational purposes.
 
 **Attributes:**
 - `id`: UUID
 - `userId`: UUID - Reference to User (must have ATHLETE role)
+- `sportId`: UUID - Reference to Sport
 - `level`: AthleteLevel - BEGINNER | INTERMEDIATE | ADVANCED
 - `createdAt`: Timestamp
 - `updatedAt`: Timestamp
 
 **Responsibilities:**
-- Track athlete skill progression
+- Track athlete skill progression per sport
 - Provide context for session recommendations
 - Enable level-based analytics
+- Support multi-sport athletes with different skill levels
 
 **Business Rules:**
-1. User must have ATHLETE role to have an AthleteProfile
+1. User must have ATHLETE role to have AthleteProfile
 2. Level is informational only - doesn't restrict session attendance
 3. Only Committee members with MANAGE_ATHLETES privilege can modify levels
 4. Level changes are tracked in AthleteProfileHistory
+5. One profile per user per sport (unique: userId + sportId)
+6. Athletes can have different levels in different sports
 
 **Use Cases:**
-- Help athletes find appropriate sessions (e.g., Intermediate athlete sees "Tuesday Advanced" session)
+- Help athletes find appropriate sessions (e.g., Intermediate volleyball athlete sees "Tuesday Advanced" session)
 - Allow cross-level attendance (Advanced athlete can help in Beginner session)
-- Track athlete progression over time
+- Track athlete progression over time per sport
+- Support multi-sport athletes (e.g., João: ADVANCED in Volleyball, BEGINNER in Padel)
 
 ---
 
@@ -381,8 +386,11 @@ The bridge entity managing the many-to-many relationship between Users (Athletes
 User (1) ---- (1..N) UserRole
    User must have at least one role
 
-User (1) ---- (0..1) AthleteProfile
-   User with ATHLETE role has one AthleteProfile
+User (1) ---- (0..N) AthleteProfile
+   User with ATHLETE role can have profiles for multiple sports
+
+Sport (1) ---- (0..N) AthleteProfile
+   Sport can have many athlete profiles at different levels
 
 AthleteProfile (1) ---- (0..N) AthleteProfileHistory
    Profile can have many level change records
@@ -727,20 +735,21 @@ fun assignRole(userId: UUID, newRole: Role) {
 1. **User Role Requirement**: Every User must have at least one UserRole
 2. **Role Mutual Exclusivity**: User cannot have both ATHLETE and SUPPORTER roles
 3. **Athlete Profile Constraint**: Only users with ATHLETE role can have AthleteProfile
-4. **Committee Admin Existence**: System must always have at least one COMMITTEE_ADMIN
-5. **Athlete Attendance Only**: Only users with ATHLETE role can have Attendance records
-6. **Valid Session Status**: TrainingSession status must be SCHEDULED, CANCELLED, or COMPLETED
-7. **Capacity Constraint**: Confirmed attendance count ≤ session capacity
-8. **Unique Email**: Each User email must be unique in the system
-9. **Future Sessions Only**: Cannot create sessions in the past
-10. **Valid Attendance Status**: Attendance status must be PENDING, CONFIRMED, or CANCELLED
-11. **Calendar Sequential**: CalendarAccess periods must be sequential with no gaps
-12. **Calendar Limit**: Cannot unlock calendar beyond 3 months ahead
-13. **Venue Sport Tags**: TrainingSession venue must have session's sport in sportTags
-14. **Unique Venue Names**: Each Venue name must be unique
-15. **Unique Role Assignment**: User cannot have duplicate roles
-16. **Session Within Unlock**: TrainingSession date must be within CalendarAccess period
-17. **Level Change Audit**: Every AthleteProfile level change must create AthleteProfileHistory record
+4. **Sport-Specific Profile**: One AthleteProfile per user per sport (unique: userId + sportId)
+5. **Committee Admin Existence**: System must always have at least one COMMITTEE_ADMIN
+6. **Athlete Attendance Only**: Only users with ATHLETE role can have Attendance records
+7. **Valid Session Status**: TrainingSession status must be SCHEDULED, CANCELLED, or COMPLETED
+8. **Capacity Constraint**: Confirmed attendance count ≤ session capacity
+9. **Unique Email**: Each User email must be unique in the system
+10. **Future Sessions Only**: Cannot create sessions in the past
+11. **Valid Attendance Status**: Attendance status must be PENDING, CONFIRMED, or CANCELLED
+12. **Calendar Sequential**: CalendarAccess periods must be sequential with no gaps
+13. **Calendar Limit**: Cannot unlock calendar beyond 3 months ahead
+14. **Venue Sport Tags**: TrainingSession venue must have session's sport in sportTags
+15. **Unique Venue Names**: Each Venue name must be unique
+16. **Unique Role Assignment**: User cannot have duplicate roles
+17. **Session Within Unlock**: TrainingSession date must be within CalendarAccess period
+18. **Level Change Audit**: Every AthleteProfile level change must create AthleteProfileHistory record
 
 ---
 
@@ -813,8 +822,10 @@ interface UserRoleRepository {
 }
 
 interface AthleteProfileRepository {
-    suspend fun findByUserId(userId: UUID): AthleteProfile?
-    suspend fun findByLevel(level: AthleteLevel): List<AthleteProfile>
+    suspend fun findByUserId(userId: UUID): List<AthleteProfile>
+    suspend fun findByUserIdAndSportId(userId: UUID, sportId: UUID): AthleteProfile?
+    suspend fun findBySportId(sportId: UUID): List<AthleteProfile>
+    suspend fun findByLevel(sportId: UUID, level: AthleteLevel): List<AthleteProfile>
     suspend fun save(profile: AthleteProfile): AthleteProfile
 }
 

--- a/docs/domain/class-diagram.md
+++ b/docs/domain/class-diagram.md
@@ -35,6 +35,7 @@ classDiagram
     class AthleteProfile {
         +UUID id
         +UUID userId
+        +UUID sportId
         +AthleteLevel level
         +DateTime createdAt
         +DateTime updatedAt
@@ -191,7 +192,8 @@ classDiagram
 
     %% Relationships
     User "1" --> "1..*" UserRole : has
-    User "1" --> "0..1" AthleteProfile : has
+    User "1" --> "0..*" AthleteProfile : has
+    Sport "1" --> "0..*" AthleteProfile : defines levels for
     AthleteProfile "1" --> "0..*" AthleteProfileHistory : tracks
     Sport "1" --> "0..*" TrainingSession : contains
     Sport "1" --> "0..*" CalendarAccess : controls
@@ -199,20 +201,19 @@ classDiagram
     Venue "1" --> "0..*" TrainingSession : hosts
     SessionTemplate "1" ..> "0..*" TrainingSession : generates
     TrainingSession "1" --> "0..*" Attendance : has
-    User "1" --> "0..*" Attendance : participates
+    User "1" --> "0..*" Attendance : creates
 
     User --> UserStatus : status
     UserRole --> Role : role
     UserRole --> CommitteePrivilege : privileges
     AthleteProfile --> AthleteLevel : level
+    AthleteProfile --> Sport : for sport
     AthleteProfileHistory --> AthleteLevel : oldLevel/newLevel
     TrainingSession --> SessionStatus : status
     TrainingSession --> SessionLevel : targetLevel
     TrainingSession --> Sport : belongs to
     TrainingSession --> Venue : located at
     Attendance --> AttendanceStatus : status
-    Attendance --> User : athlete
-    Attendance --> TrainingSession : session
 ```
 
 ## Entity Details
@@ -251,7 +252,7 @@ classDiagram
 ---
 
 ### AthleteProfile
-**Entity** storing athlete-specific information like skill level.
+**Entity** storing athlete-specific information like skill level per sport.
 
 **Key Methods:**
 - `getHistory()`: Get all level change history records
@@ -259,11 +260,12 @@ classDiagram
 **Invariants:**
 - User must have ATHLETE role to have AthleteProfile
 - Level is informational - doesn't restrict session attendance
-- One profile per user
+- One profile per user per sport (unique: userId + sportId)
 
 **Business Rules:**
 - Only Committee with MANAGE_ATHLETES privilege can modify level
 - Level changes automatically create history records
+- Athletes can have different levels in different sports (e.g., ADVANCED in Volleyball, BEGINNER in Padel)
 
 ---
 
@@ -460,20 +462,20 @@ classDiagram
 | Relationship | Cardinality | Description |
 |--------------|-------------|-------------|
 | User → UserRole | 1 to many | A user must have at least one role, can have multiple |
-| User → AthleteProfile | 1 to 0..1 | A user with ATHLETE role has one AthleteProfile |
+| User → AthleteProfile | 1 to many | A user with ATHLETE role can have profiles for multiple sports |
+| Sport → AthleteProfile | 1 to many | A sport can have many athlete profiles at different levels |
 | AthleteProfile → AthleteProfileHistory | 1 to many | Profile can have many level change records |
 | Sport → TrainingSession | 1 to many | A sport can have zero or more training sessions |
 | Sport → CalendarAccess | 1 to many | Each sport has independent calendar access records |
 | Sport → SessionTemplate | 1 to many | Sport can have many recurring templates |
-| Sport → Venue | many to many | Many sports can use many venues (via sportTags) |
 | Venue → TrainingSession | 1 to many | Venue can host many sessions |
 | SessionTemplate → TrainingSession | 1 to many | Template can generate many sessions (conceptually) |
 | TrainingSession → Attendance | 1 to many | A session can have zero or more attendance records |
 | User → Attendance | 1 to many | A user can attend zero or more sessions |
 | TrainingSession → Sport | many to 1 | Each session belongs to exactly one sport |
 | TrainingSession → Venue | many to 1 | Each session is at exactly one venue |
-| Attendance → User | many to 1 | Each attendance is for exactly one user |
-| Attendance → TrainingSession | many to 1 | Each attendance is for exactly one session |
+| AthleteProfile → User | many to 1 | Each profile belongs to exactly one user |
+| AthleteProfile → Sport | many to 1 | Each profile is for exactly one sport |
 
 ---
 

--- a/docs/domain/er-diagram.md
+++ b/docs/domain/er-diagram.md
@@ -7,7 +7,8 @@ This diagram shows the database/persistence perspective of our domain model.
 ```mermaid
 erDiagram
     USER ||--o{ USER_ROLE : has
-    USER ||--o| ATHLETE_PROFILE : has
+    USER ||--o{ ATHLETE_PROFILE : has
+    SPORT ||--o{ ATHLETE_PROFILE : defines_levels_for
     ATHLETE_PROFILE ||--o{ ATHLETE_PROFILE_HISTORY : tracks
     SPORT ||--o{ TRAINING_SESSION : contains
     SPORT ||--o{ CALENDAR_ACCESS : controls
@@ -39,7 +40,8 @@ erDiagram
 
     ATHLETE_PROFILE {
         uuid id PK
-        uuid user_id FK "unique"
+        uuid user_id FK
+        uuid sport_id FK
         string level "BEGINNER|INTERMEDIATE|ADVANCED"
         timestamp created_at
         timestamp updated_at
@@ -177,7 +179,8 @@ erDiagram
 | Column | Type | Constraints | Description |
 |--------|------|-------------|-------------|
 | id | UUID | PRIMARY KEY | Unique profile identifier |
-| user_id | UUID | FOREIGN KEY (USER), UNIQUE, NOT NULL | Reference to user (one-to-one) |
+| user_id | UUID | FOREIGN KEY (USER), NOT NULL | Reference to user |
+| sport_id | UUID | FOREIGN KEY (SPORT), NOT NULL | Reference to sport |
 | level | VARCHAR(20) | NOT NULL | Athlete skill level (BEGINNER, INTERMEDIATE, ADVANCED) |
 | created_at | TIMESTAMP | NOT NULL | Profile creation timestamp |
 | updated_at | TIMESTAMP | NOT NULL | Last update timestamp |
@@ -185,13 +188,15 @@ erDiagram
 **Indexes:**
 - Primary: `id`
 - Foreign Key: `user_id` → `USER(id)`
-- Unique: `user_id` (one profile per user)
+- Foreign Key: `sport_id` → `SPORT(id)`
+- Unique Composite: `(user_id, sport_id)` (one profile per user per sport)
 - Index: `level` (for filtering by level)
+- Index: `sport_id` (for sport-specific queries)
 
 **Constraints:**
 - User must have ATHLETE role to have AthleteProfile
 - Level is informational only - doesn't restrict session attendance
-- One profile per user
+- One profile per user per sport (e.g., João: ADVANCED in Volleyball, BEGINNER in Padel)
 
 ---
 
@@ -410,11 +415,16 @@ ADD CONSTRAINT fk_user_role_assigned_by
 FOREIGN KEY (assigned_by) REFERENCES USER(id)
 ON DELETE SET NULL;
 
--- ATHLETE_PROFILE references USER
+-- ATHLETE_PROFILE references USER and SPORT
 ALTER TABLE ATHLETE_PROFILE
 ADD CONSTRAINT fk_athlete_profile_user
 FOREIGN KEY (user_id) REFERENCES USER(id)
 ON DELETE CASCADE;
+
+ALTER TABLE ATHLETE_PROFILE
+ADD CONSTRAINT fk_athlete_profile_sport
+FOREIGN KEY (sport_id) REFERENCES SPORT(id)
+ON DELETE RESTRICT;
 
 -- ATHLETE_PROFILE_HISTORY references ATHLETE_PROFILE
 ALTER TABLE ATHLETE_PROFILE_HISTORY
@@ -493,9 +503,9 @@ ADD CONSTRAINT uk_user_email UNIQUE (email);
 ALTER TABLE USER_ROLE
 ADD CONSTRAINT uk_user_role_type UNIQUE (user_id, role);
 
--- User can have only one athlete profile
+-- User can have only one athlete profile per sport
 ALTER TABLE ATHLETE_PROFILE
-ADD CONSTRAINT uk_athlete_profile_user UNIQUE (user_id);
+ADD CONSTRAINT uk_athlete_profile_user_sport UNIQUE (user_id, sport_id);
 
 -- Sport name must be unique
 ALTER TABLE SPORT

--- a/docs/domain/use-cases.md
+++ b/docs/domain/use-cases.md
@@ -714,51 +714,59 @@ graph TB
 
 **Actor:** Committee Member with MANAGE_ATHLETES privilege
 
-**Goal:** Update athlete's skill level with audit trail
+**Goal:** Update athlete's skill level for a specific sport with audit trail
 
 **Preconditions:**
 - User has Committee role with MANAGE_ATHLETES privilege
-- Target user has ATHLETE role and AthleteProfile
+- Target user has ATHLETE role and AthleteProfile for the sport
 
 **Main Flow:**
 1. Committee member views athlete list
 2. Committee member selects athlete
-3. System displays current level and history
-4. Committee member selects new level:
+3. Committee member selects sport
+4. System displays current level and history for that sport
+5. Committee member selects new level:
    - BEGINNER
    - INTERMEDIATE
    - ADVANCED
-5. Committee member enters optional reason for change
-6. System validates:
+6. Committee member enters optional reason for change
+7. System validates:
    - User has MANAGE_ATHLETES privilege
+   - AthleteProfile exists for user + sport combination
    - New level is different from current
-7. System updates AthleteProfile.level
-8. System creates AthleteProfileHistory record:
+8. System updates AthleteProfile.level for that sport
+9. System creates AthleteProfileHistory record:
    - old_level = current level
    - new_level = selected level
    - changed_by = Committee member
    - changed_at = timestamp
    - reason = optional explanation
-9. System displays success message
+10. System displays success message
 
 **Postconditions:**
-- AthleteProfile updated with new level
+- AthleteProfile updated with new level for specific sport
 - AthleteProfileHistory record created (immutable audit trail)
-- Level change tracked
+- Level change tracked per sport
 
 **Alternative Flows:**
 - **A1: Same Level**
-  - If new level equals current level
+  - If new level equals current level for that sport
   - System shows info: "Level unchanged"
-- **A2: No Athlete Profile**
-  - If user doesn't have ATHLETE role
-  - System shows error: "User is not an athlete"
+- **A2: No Athlete Profile for Sport**
+  - If user doesn't have AthleteProfile for selected sport
+  - System shows error: "User is not registered as athlete for this sport"
+  - System offers to create new AthleteProfile
+- **A3: Create Profile for New Sport**
+  - Committee member creates AthleteProfile for user + sport
+  - Sets initial level
+  - History record created with null old_level
 
 **Business Rules:**
 - Only Committee with MANAGE_ATHLETES privilege can modify
 - Level is informational - doesn't restrict session attendance
 - History is immutable (cannot be deleted)
 - First history record has null old_level
+- Athletes can have different levels in different sports (e.g., ADVANCED in Volleyball, BEGINNER in Padel)
 - MVP: Data captured, UI viewing is future feature
 
 ---


### PR DESCRIPTION
Major changes:

**Sport-Specific AthleteProfile:**
- Added sportId to AthleteProfile entity
- Changed User → AthleteProfile cardinality from 0..1 to 0..*
- Athletes can now have different levels in different sports Example: João (ADVANCED in Volleyball, BEGINNER in Padel)
- Unique constraint: (userId, sportId) instead of just userId
- Updated repository interfaces to support sport-specific queries

**Fixed Circular Relationships in Class Diagram:**
- Removed redundant Attendance → User relationship
- Removed redundant Attendance → TrainingSession relationship
- Removed redundant TrainingSession → Sport relationship
- Removed redundant TrainingSession → Venue relationship
- Each relationship now shown only once with proper cardinality

**Updated Files:**
- class-diagram.md: Added sportId, fixed relationships, updated cardinality table
- er-diagram.md: Added sport_id FK, updated unique constraint, added Sport relationship
- README.md: Updated entity description, business rules, invariants, repository interface
- use-cases.md: Updated UC-16 to include sport selection and multi-sport scenarios

**Business Rules:**
- One AthleteProfile per user per sport (not per user)
- Level is informational and sport-specific
- Athletes can have different skill levels in different sports
- Committee can manage athlete levels per sport independently