### PR TITLE
Remove remaining circular dependencies in class diagram

### DIFF
--- a/docs/domain/class-diagram.md
+++ b/docs/domain/class-diagram.md
@@ -207,12 +207,9 @@ classDiagram
     UserRole --> Role : role
     UserRole --> CommitteePrivilege : privileges
     AthleteProfile --> AthleteLevel : level
-    AthleteProfile --> Sport : for sport
     AthleteProfileHistory --> AthleteLevel : oldLevel/newLevel
     TrainingSession --> SessionStatus : status
     TrainingSession --> SessionLevel : targetLevel
-    TrainingSession --> Sport : belongs to
-    TrainingSession --> Venue : located at
     Attendance --> AttendanceStatus : status
 ```
 


### PR DESCRIPTION
Removed redundant simple reference arrows:
- AthleteProfile --> Sport (already have Sport --> AthleteProfile with cardinality)
- TrainingSession --> Sport (already have Sport --> TrainingSession with cardinality)
- TrainingSession --> Venue (already have Venue --> TrainingSession with cardinality)

The association arrows with cardinality are sufficient to show the relationships. All circular dependencies now resolved.